### PR TITLE
linux-libc-dev should ship armhf headers, not arm64

### DIFF
--- a/debian/rules.real
+++ b/debian/rules.real
@@ -309,8 +309,8 @@ install-libc-dev_$(ARCH):
 	dh_prep
 	rm -rf '$(DIR)'
 	mkdir -p $(DIR)
-	+$(MAKE_CLEAN) O='$(CURDIR)/$(DIR)' headers_check ARCH=$(KERNEL_ARCH)
-	+$(MAKE_CLEAN) O='$(CURDIR)/$(DIR)' headers_install ARCH=$(KERNEL_ARCH) INSTALL_HDR_PATH='$(CURDIR)'/$(OUT_DIR)
+	+$(MAKE_CLEAN) O='$(CURDIR)/$(DIR)' headers_check ARCH=arm
+	+$(MAKE_CLEAN) O='$(CURDIR)/$(DIR)' headers_install ARCH=arm INSTALL_HDR_PATH='$(CURDIR)'/$(OUT_DIR)
 
 	rm -rf $(OUT_DIR)/include/drm $(OUT_DIR)/include/scsi
 	find $(OUT_DIR)/include \( -name .install -o -name ..install.cmd \) -execdir rm {} +


### PR DESCRIPTION
Signed-off-by: Carlo Caione <carlo@endlessm.com>