### PR TITLE
syscall: Fix panic when calling memfd_create()

### DIFF
--- a/arch/arm64/include/asm/unistd.h
+++ b/arch/arm64/include/asm/unistd.h
@@ -43,7 +43,7 @@
 #define __ARM_NR_compat_cacheflush	(__ARM_NR_COMPAT_BASE+2)
 #define __ARM_NR_compat_set_tls		(__ARM_NR_COMPAT_BASE+5)
 
-#define __NR_compat_syscalls		386
+#define __NR_compat_syscalls		385
 #endif
 
 #define __ARCH_WANT_SYS_CLONE


### PR DESCRIPTION
https://phabricator.endlessm.com/T18892