### PR TITLE
Don't install linux-libc-dev package

### DIFF
--- a/debian/bin/gencontrol.py
+++ b/debian/bin/gencontrol.py
@@ -140,8 +140,10 @@ class Gencontrol(Base):
             headers_arch = self.templates["control.headers.arch"]
             packages_headers_arch = self.process_packages(headers_arch, vars)
 
-        libc_dev = self.templates["control.libc-dev"]
-        packages_headers_arch[0:0] = self.process_packages(libc_dev, {})
+        # Don't install linux-libc-dev
+        # https://phabricator.endlessm.com/T19475
+        #libc_dev = self.templates["control.libc-dev"]
+        #packages_headers_arch[0:0] = self.process_packages(libc_dev, {})
 
         packages_headers_arch[-1]['Depends'].extend(PackageRelation())
         extra['headers_arch_depends'] = packages_headers_arch[-1]['Depends']

--- a/debian/control
+++ b/debian/control
@@ -10,19 +10,6 @@ Vcs-Svn: svn://anonscm.debian.org/svn/kernel/dists/trunk/linux/
 Vcs-Browser: http://anonscm.debian.org/viewvc/kernel/dists/trunk/linux/
 Homepage: https://www.kernel.org/
 
-Package: linux-libc-dev
-Architecture: armhf
-Section: devel
-Provides: linux-kernel-headers
-Depends: ${misc:Depends}
-Replaces: linux-kernel-headers
-Conflicts: linux-kernel-headers
-Description: Linux support headers for userspace development
- This package provides userspaces headers from the Linux kernel.  These
- headers are used by the installed headers for GNU libc and other system
- libraries.
-Multi-Arch: same
-
 Package: linux-headers-3.14-2-all
 Architecture: armhf
 Depends: linux-headers-3.14-2-all-${kernel:Arch} (= ${binary:Version}), ${misc:Depends}

--- a/debian/rules.real
+++ b/debian/rules.real
@@ -53,7 +53,10 @@ MAKEOVERRIDES =
 ifneq ($(FOREIGN_KERNEL),True)
   binary-arch-arch: install-headers_$(ARCH)
 endif
-binary-arch-arch: install-libc-dev_$(ARCH)
+# Don't install linux-libc-dev
+# https://phabricator.endlessm.com/T19475
+#binary-arch-arch: install-libc-dev_$(ARCH)
+binary-arch-arch:
 binary-arch-featureset: install-headers_$(ARCH)_$(FEATURESET)
 binary-arch-flavour: install-image_$(ARCH)_$(FEATURESET)_$(FLAVOUR)_$(TYPE)
 ifeq ($(DEBUG),True)


### PR DESCRIPTION
The linux-libc-dev package contains the kernel headers used by glibc. We
want these to come from the latest kernel package, linux, and not from
the platform specific kernel packages. Reprepro can handle duplicate
packages by only keeping the latest version, but OBS handles this by
keeping the most recently built version.

That's now breaking libc6-dev since it has a versioned linux-libc-dev
dependency based on the version it was built against. The other header
and source related packages are OK to keep since the package names
correspond to the kernel ABI being built.

https://phabricator.endlessm.com/T19475